### PR TITLE
variants of download.py to feed edex

### DIFF
--- a/JH.README
+++ b/JH.README
@@ -1,0 +1,23 @@
+
+This will get your AWIPS II installation rolling.
+
+nexdown.py - Used for fetching radar data from the inoaaport feed, tosses it into
+the data_store directory, and then notifies edex
+
+wiredown.py - Does the same thing for the nwws inoaaport feed, and has a couple of
+functions for special handling of warnings and notices.  You may want to kill off
+those functions, as it will drop all those products in /awips2/local/spool/warnprint
+and noticeprint.  Not all that useful at the moment, but you could use it to print
+warnings.
+
+You will want to use start_nwws.sh and start_radar.sh to start these as the awips user.
+It fires off the python scripts under screen.  Since the radar feed under regular
+conditions is over 1Mbps, it's probably rude to leave it running 24/7.  I run it as
+needed.  AWIPS won't care, although it appears that CAVE may need to be restarted
+if it has never seen radar products and they suddenly show up.
+
+I have included inoaaport_ids.py and wmo.py which are used to feed 1.nbsp into ldm. 
+The wmo.py module is a simple class that is used to emit a proper WMO GTS-style 
+stream.  The inoaaport_ids.py script is a modification of download.py and should
+be started by ldmd using an EXEC statement in your ldmd.conf.  I'm not sure if this
+is the right way to go, but it does work.

--- a/inoaaport_ids.py
+++ b/inoaaport_ids.py
@@ -69,7 +69,7 @@ class Streamer(object):
 
 
 def main():
-    pqp = os.popen("/usr/local/ldm/bin/pqing -f IDS -l /usr/local/ldm/var/logs/ids_noaaport.log -v -", 'w')
+    pqp = os.popen("/awips2/ldm/bin/pqing -f IDS -l /awips2/ldm/var/logs/ids_noaaport.log -v -", 'w')
     s = Streamer([('1.nbsp.inoaaport.net', 2210)], 'IDS', pqp)
     s.run()
 

--- a/inoaaport_ids.py
+++ b/inoaaport_ids.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+import logging
+import socket
+import os.path
+import os
+import sys
+import shutil
+from wmo import WMO
+
+import nbs
+
+
+class Streamer(object):
+    def __init__(self, hosts, feed, outch):
+        self.hosts = hosts
+        #self.log = logging.getLogger('nbs')
+        #self.log.setLevel(logging.DEBUG)
+        self.files = {}
+        self.count = 0
+        self.wmo = WMO(outch)
+
+    def stream(self, host):
+        #self.log.info('Connecting to %s:%i' % host)
+        self.sock = socket.socket()
+        self.sock.connect(host)
+        return nbs.Connection(self.sock)
+
+    def reliable_stream(self):
+        i = 0
+        while True:
+            try:
+                for packet in self.stream(self.hosts[i]):
+                    yield packet
+            except Exception, e:
+                None
+                #self.log.error('Stream error %r: %s' % (self.hosts[i], str(e)))
+            i = (i + 1) % len(self.hosts)
+
+    def handle_incoming(self, filename, content):
+        self.count += 1
+        del self.files[filename]
+        #self.log.debug(filename)
+        ccblen = 2 * (((ord(content[0]) & 63) << 8) + ord(content[1]))
+        self.wmo.emit(content[ccblen:])
+        #outfile = "%s/%s" % (self.outdir, filename)
+        #if not os.path.exists(self.outdir):
+        #    os.makedirs(self.outdir)
+        #fd = file(outfile, 'w')
+        #fd.write(content[ccblen:])
+        #fd.flush()
+        #fd.close()
+        #try:
+        #  hdr = content[ccblen:].splitlines()[0].strip()
+        #  self.log.debug("   %s %06d" % (hdr, self.count))
+        #  shutil.move(outfile, "/awips2/edex/data/manual/")
+        #  #os.system("/awips2/ldm/bin/pqinsert -p \"%s\" -l - %s" % (hdr, outfile))
+        #except:
+        #  print "INGEST FAILED"
+  
+
+    def run(self):
+        for packet in self.reliable_stream():
+            if not packet.filename in self.files:
+                self.files[packet.filename] = nbs.FileAssembler(
+                    packet.filename, self.handle_incoming)
+            assembler = self.files[packet.filename]
+            assembler.add_part(packet)
+            #self.log.debug(repr(packet))
+
+
+def main():
+    pqp = os.popen("/usr/local/ldm/bin/pqing -f IDS -l /usr/local/ldm/var/logs/ids_noaaport.log -v -", 'w')
+    s = Streamer([('1.nbsp.inoaaport.net', 2210)], 'IDS', pqp)
+    s.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/nexdown.py
+++ b/nexdown.py
@@ -1,0 +1,88 @@
+#!/awips2/python/bin/python
+import logging
+import socket
+import os.path
+import os
+import sys
+import shutil
+import time
+
+import nbs
+
+# For edex notifications
+from ufpy.qpidingest import *
+
+class Streamer(object):
+    def __init__(self, hosts):
+        self.hosts = hosts
+        self.log = logging.getLogger('nbs')
+        self.log.setLevel(logging.DEBUG)
+        self.files = {}
+        self.outdir = "/awips2/data_store/radar/{SITE}/{PCODE}/{WMO}_{SITE}_{PCODE}_{TIME}.rad"
+        self.count = 0
+    def stream(self, host):
+        self.log.info('Connecting to %s:%i' % host)
+        self.sock = socket.socket()
+        self.sock.connect(host)
+        return nbs.Connection(self.sock)
+
+    def reliable_stream(self):
+        i = 0
+        while True:
+            try:
+                for packet in self.stream(self.hosts[i]):
+                    yield packet
+            except Exception, e:
+                self.log.error('Stream error %r: %s' % (self.hosts[i], str(e)))
+            i = (i + 1) % len(self.hosts)
+
+    def handle_incoming(self, filename, content):
+        self.count += 1
+        del self.files[filename]
+        #self.log.debug(filename)
+        ccblen = 2 * (((ord(content[0]) & 63) << 8) + ord(content[1]))
+        # We need to build awips path name here
+        # /awips2/data_store/radar/(SITE)/(PCODE)/(WMO)_(SITE)_(PCODE)_(DATE)_(seq).rad
+        #outfile = "%s/%s" % (self.outdir, filename)
+        hdr = content[ccblen:].splitlines()
+        (wmo,site,ts) = hdr[0].split(' ', 3)
+        (dd,hh,mm) = (ts[0:2], ts[2:4], ts[4:6])
+        # ['SDUS84 KOUN 260459', '', 'N0HFDR', '', ...
+        pil = hdr[2]
+        pcode = pil[0:3]
+        # dir DATE is receive date
+        outdir = "/awips2/data_store/radar/{DATE}/{HR}/{SITE}/{PCODE}".format(DATE=time.strftime("%Y%m%d"), HR=time.strftime("%H"), SITE=site, PCODE=pil[0:3])
+        outfile = "{WMO}_{SITE}_{PIL}_{DATE}.rad".format(WMO=wmo, SITE=site, PIL=pil, DATE=ts)
+        odof = "%s/%s" % (outdir,outfile)
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+        fd = file(odof, 'w')
+        fd.write(content)
+        fd.flush()
+        fd.close()
+        npcode = "%s /p%s" % (hdr[0], pil)
+        self.log.debug("%s (%s)" % (odof, npcode))
+        z.sendmessage(odof, npcode)
+  
+
+    def run(self):
+        for packet in self.reliable_stream():
+            if not packet.filename in self.files:
+                self.files[packet.filename] = nbs.FileAssembler(
+                    packet.filename, self.handle_incoming)
+            assembler = self.files[packet.filename]
+            assembler.add_part(packet)
+            #self.log.debug(repr(packet))
+
+
+def main():
+    host = "3.nbsp.inoaaport.net"
+    port = 2210
+    s = Streamer([(host, port)])
+    s.run()
+
+
+if __name__ == '__main__':
+    os.environ['TZ'] = 'GMT'
+    z = IngestViaQPID()
+    main()

--- a/start_nwws.sh
+++ b/start_nwws.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /awips2/local/spool/warnprint /awips2/local/spool/noticeprint
+screen  -t wiredown -dmS wiredown /home/awips/python-emwin/wiredown.py

--- a/start_radar.sh
+++ b/start_radar.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+screen  -t nexdown -dmS nexdown /home/awips/python-emwin/nexdown.py

--- a/wiredown.py
+++ b/wiredown.py
@@ -1,0 +1,207 @@
+#!/awips2/python/bin/python
+import logging
+import socket
+import os.path
+import os
+import sys
+import shutil
+
+import nbs
+
+import time
+
+# For edex notifications
+from ufpy.qpidingest import *
+
+warnprintdir = "/awips2/local/spool/warnprint"
+noticeprintdir = "/awips2/local/spool/noticeprint"
+
+
+class Streamer(object):
+    def __init__(self, hosts):
+        self.hosts = hosts
+        self.log = logging.getLogger('nbs')
+        self.log.setLevel(logging.DEBUG)
+        self.files = {}
+        self.count = 0
+        self.basedir = "/awips2/data_store"
+
+    def stream(self, host):
+        self.log.info('Connecting to %s:%i' % host)
+        self.sock = socket.socket()
+        self.sock.connect(host)
+        return nbs.Connection(self.sock)
+
+    def reliable_stream(self):
+        i = 0
+        while True:
+            try:
+                for packet in self.stream(self.hosts[i]):
+                    yield packet
+            except Exception, e:
+                self.log.error('Stream error %r: %s' % (self.hosts[i], str(e)))
+            i = (i + 1) % len(self.hosts)
+
+    def handle_incoming(self, filename, content):
+        self.count += 1
+        del self.files[filename]
+        self.log.debug(filename)
+        ccblen = 2 * (((ord(content[0]) & 63) << 8) + ord(content[1]))
+        hdr = content[ccblen:].splitlines()
+        # initialize these to gibberish just in case
+        # processing the header fails
+        (wmo,site,ts) = ('NPHX99', 'UNKN', time.strftime("%d%H%M"))
+        pil = "NONPIL"
+        try:
+            (wmo,site,ts) = hdr[0].split(' ')[0:3]
+            pil = hdr[2]
+        except:
+            print "WTF\n\tHDR 1: %s\n\tHDR 2: %s\n\tHDR 3: %s\n\tHDR 4: %s\n\tHDR 5: %s\n" % (hdr[0], hdr[1], hdr[2], hdr[3], hdr[4])
+        if pil == '@pil':
+           # KNCF is currently dropping in @pil as the pilcode
+           pil = 'MONMSG'
+        if wmo[0:2] == 'NT':
+          outdir = "{BASEDIR}/tstmsg/{SITE}".format(BASEDIR=self.basedir, SITE=site)
+          outfile = "{WMO}_{SITE}_{DATE}_{WALLTIME}".format(WMO=wmo, SITE=site, DATE=ts, WALLTIME=time.strftime("%Y%m%d%H%M%S"))
+        elif pil == 'MONMSG':
+          outdir = "{BASEDIR}/tstmsg/{SITE}".format(BASEDIR=self.basedir, SITE=site)
+          outfile = "{WMO}_{SITE}_{DATE}_{WALLTIME}".format(WMO=wmo, SITE=site, DATE=ts, WALLTIME=time.strftime("%Y%m%d%H%M%S"))
+        else:   
+          outdir = "{BASEDIR}/nwws/{DATE}/{HR}/{SITE}".format(BASEDIR=self.basedir, DATE=time.strftime("%Y%m%d"), HR=time.strftime("%H"), SITE=site)
+          outfile = "{WMO}_{SITE}_{PIL}_{DATE}.txt".format(WMO=wmo, SITE=site, PIL=pil.replace(' ', '_'), DATE=ts)
+        odof = "%s/%s" % (outdir,outfile)
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+        fd = file(odof, 'w')
+        fd.write(content[ccblen:])
+        fd.flush()
+        fd.close()
+        npcode = "%s /p%s" % (hdr[0], pil)
+        self.log.debug("%s (%s)" % (odof, npcode))
+        z.sendmessage(odof, npcode)
+        if wmo[0] == 'W':
+            do_warn(wmo, site, pil, content[ccblen:])
+        if wmo[1] == 'N':
+            do_notice(wmo, site, pil, content[ccblen:])
+
+  
+
+    def run(self):
+        for packet in self.reliable_stream():
+            if not packet.filename in self.files:
+                self.files[packet.filename] = nbs.FileAssembler(
+                    packet.filename, self.handle_incoming)
+            assembler = self.files[packet.filename]
+            assembler.add_part(packet)
+            #self.log.debug(repr(packet))
+
+"""
+The idea with the do_{warn,canwarn,notice} functions is that they would be used
+for immediate and special handling of warnings and notices.  Presently, I think
+I'll have them print out.  In the future, we may do something crazy involving
+blinkenlights and buzzers.
+
+Since the WMO codes are highly regular, it is much easier to determine if a 
+product is actually important.  First letter = 'W' is a warning.  First letter
+is 'N', it's a notice.  Second letter of notice is 'W'?  Well, that's a notice
+about a warning, which is generally a cancellation.
+
+See https://www.wmo.int/pages/prog/www/ois/Operational_Information/Publications/WMO_386/AHLsymbols/TableB1.html
+for all the goodies
+
+Where WMO codes break down and the PIL takes over is when we see things
+like localized forecasts.  KJAN will produce numerous reports for a 
+whole slew of products for various cities and they'll have the same WMO
+code.  For example, JAN issues CLI products for several cities under
+the same WMO code:
+
+fxatext=# select distinct cccid, nnnid, site, wmoid, xxxid, bbbid, nnnid || xxxid as pil from stdtextproducts where nnnid = 'CLI' and site = 'KJAN' and xxxid != 'JAN' ;         
+ cccid | nnnid | site | wmoid  | xxxid | bbbid |  pil   
+-------+-------+------+--------+-------+-------+--------
+ JAN   | CLI   | KJAN | CDUS44 | GLH   |       | CLIGLH
+ JAN   | CLI   | KJAN | CDUS44 | HBG   |       | CLIHBG
+ JAN   | CLI   | KJAN | CDUS44 | MEI   |       | CLIMEI
+ JAN   | CLI   | KJAN | CDUS44 | TVR   |       | CLITVR
+ JAN   | CLI   | KJAN | CDUS44 | GWO   |       | CLIGWO
+(5 rows)
+
+"""
+
+def do_tstmsg(wmo,site,pil,content):
+    """
+    Special handling for test messages
+    """
+    print "* * * %s sent a test message * * *" % site
+    return True
+
+def do_warn(wmo,site,pil,content):
+    """
+    Writes a warning to the warning print spool
+    """
+
+    # Special handling for test messages
+    if wmo[0:2] == 'NT':  
+       do_tstmsg(wmo,site,pil,content)
+       return True
+    elif pil == 'MONMSG':
+        do_tstmsg(wmo,site,pil,content)
+        return True
+       
+    if wmo[0:2] == 'NW':
+       print "* * * WARNING CANCELLATION * * *"
+    else:
+       print "* * * W A R N I N G  R E C E I V E D * * *"
+    print content
+    ts = time.strftime("%Y%m%d%H%M%S")
+    fp = open("%s/%s_%s_%s.txt" % (warnprintdir,wmo,pil.strip(),ts), 'w')
+    fp.write(content)
+    fp.flush()
+    fp.close()
+    return True
+   
+def do_canwarn(wmo,site,pil,content):
+    """
+    Writes a warning cancellation to the warning print spool.
+    """
+    do_warn(wmo,site,pil,content)
+
+def do_notice(wmo,site,pil,content):
+    """
+    Writes a notice to the notice print spool, unless it is
+    a warning cancellation, in which case we call do_canwarn
+    """
+
+
+    # Special handling for test messages
+    if wmo[0:2] == 'NT':
+       do_tstmsg(wmo,site,pil,content)
+       return True
+    elif pil == 'MONMSG':
+        do_tstmsg(wmo,site,pil,content)
+        return True
+
+    if wmo[1] == 'W':
+        # Special handling for warning cancellations
+        do_canwarn(wmo,site,pil,content)
+        return True
+    print "* * * NOTICE RECEIVED * * *" 
+    print content
+    ts = time.strftime("%Y%m%d%H%M%S")
+    fp = open("%s/%s_%s_%s.txt" % (noticeprintdir,wmo,pil.strip(),ts), 'w')
+    fp.write(content)
+    fp.flush()
+    fp.close()
+    return True
+
+def main():
+    (host,port,ddir) = ('w.nbsp.inoaaport.net', 2210)
+    s = Streamer([(host, port)], ddir)
+    s.run()
+
+
+if __name__ == '__main__':
+    os.makedirs(warnprintdir)
+    os.makedirs(noticeprintdir)
+    os.environ['TZ'] = 'GMT'
+    z = IngestViaQPID()
+    main()

--- a/wiredown.py
+++ b/wiredown.py
@@ -194,8 +194,8 @@ def do_notice(wmo,site,pil,content):
     return True
 
 def main():
-    (host,port,ddir) = ('w.nbsp.inoaaport.net', 2210)
-    s = Streamer([(host, port)], ddir)
+    (host,port) = ('w.nbsp.inoaaport.net', 2210)
+    s = Streamer([(host, port)])
     s.run()
 
 

--- a/wiredown.py
+++ b/wiredown.py
@@ -200,8 +200,12 @@ def main():
 
 
 if __name__ == '__main__':
-    os.makedirs(warnprintdir)
-    os.makedirs(noticeprintdir)
+    try:
+       os.makedirs(warnprintdir)
+       os.makedirs(noticeprintdir)
+    except:
+       # If you can't write to /awips2, you're probably going to have a bad time 
+       None
     os.environ['TZ'] = 'GMT'
     z = IngestViaQPID()
     main()

--- a/wmo.py
+++ b/wmo.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+import os,sys
+
+ETX = chr(0x03)
+SOH = chr(0x01)
+
+class WMO(object):
+    """
+    This class is to be used with python-emwin to format its output messages
+    in such a way that we can stuff them into ldm's pqing
+    """
+    def __init__(self, outch):
+        self.count = 0
+        # Use the write method of our output channel
+        # this makes it easy to go from stdout to a popened
+        # file handle to pqing(1)
+        self.sw = outch.write
+
+        # send a string of ETXs to make sure we're not in any products
+        # and then follow with a proper WMO ending
+        self.sw(ETX + ETX + ETX + "\r\r\n" + ETX)
+
+    def seq(self):
+        # WMO sequence numbers are from 000 to 999.  We format to three digits in the output
+        # this is a little sillier than returning the ++'d counter since we need
+        # it to start at 0, have to keep it under 1000, and want it done in one place
+        r = self.count
+        self.count += 1
+        if self.count > 999:
+            self.count = 0
+        return r
+
+    def emit(self, content):
+        # from http://www.nws.noaa.gov/tg/head.php
+        # WMO messges start with SOH, the CRCRLF string, a sequence number, and
+        # since we're using python-emwin, we need another \r\r\n before the proper
+        # address header
+        self.sw(SOH + "\r\r\n%03d\r\r\n" % self.seq())
+        # and now we emit the content
+        self.sw(content)
+        # and finally the footer
+        self.sw("\r\r\n" + ETX)


### PR DESCRIPTION
Your python-emwin package has saved me quite a bit of work in getting data into my AWIPS II setup.  I made a few variants of download.py that deal with the 1, 3, and w feeds in various ways.  Hopefully, this will help anybody else that wants to run AWIPS II and doesn't have an ldm feed from a university.  

nexdown.py - drops level 3 data into /data_store directly and notifies edex

wiredown.py - drops the nwws feed into /data_store directly and notifies edex

inoaaport_ids.py - generates WMO-compliant stream and pipes output to ldm's pqing

start_nwws.sh - starts wiredown.py under screen

start_radar.sh - starts nexdown.py under screen

wmo.py - used to generate the WMO-compliant stream

Also added a README of my own for these additions.

Note that nexdown.py and wiredown.py require ufpy.qpidingest, which is included with AWIPS II.
